### PR TITLE
Easyer output manipulation and simpler vars names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## v0.3
-- AnsiblePlaybookCmd has a Write attribute, which must be defined by user.
+- PlaybookCmd has a Write attribute, which must be defined by user.
 
 ## v0.2
 - Change package name to ansibler

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,13 +25,26 @@
 #   unused-packages = true
 
 
-[[constraint]]
-  name = "github.com/stretchr/testify"
-  version = "1.3.0"
 
 [[constraint]]
-  name = "github.com/apenella/oc-common-utils"
-  branch = "master"
+  name = "github.com/lucabodd/go-ansible"
+  version = "0.4.0"
+
+[[constraint]]
+  name = "github.com/apenella/go-common-utils"
+  version = "0.1.1"
+
+[[constraint]]
+  name = "github.com/spf13/cobra"
+  version = "1.0.0"
+
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "1.6.1"
+
+[[constraint]]
+  name = "github.com/tidwall/gjson"
+  version = "1.6.0"
 
 [prune]
   go-tests = true

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ Go-ansible is a package for running Ansible playbooks from Golang.
 This implementation is a fork of an upstream project and allows to better manipulate ansible output
 It only supports to run `ansible-playbook` with the most of its options.
 
-To run a `ansible-playbook` command you must define three objectes:
+To run a `ansible-playbook` command you must define four objectes:
 - **PlaybookCmd** object is the main object which defines the `ansible-playbook` command and how to execute it.
 - **PlaybookOptions** object has those parameters described on `Options` section within ansible-playbook's man page, and which defines how should be the `ansible-playbook` execution behavior and where to find execution configuration
 - **PlaybookConnectionOptions** object has those parameters described on `Connections Options` section within ansible-playbook's man page, and which defines how to connect to hosts.
+- **PlaybookResults** object that will be filled up with results after a ansible run
 
 ## Executor
 Go-ansible package has its own and default executor implementation which runs the `ansible-playbook`command and prints its output with a prefix on each line.

--- a/README.md
+++ b/README.md
@@ -4,20 +4,20 @@ Go-ansible is a package for running Ansible playbooks from Golang.
 It only supports to run `ansible-playbook` with the most of its options.
 
 To run a `ansible-playbook` command you must define three objectes:
-- **AnsiblePlaybookCmd** object is the main object which defines the `ansible-playbook` command and how to execute it.
-- **AnsiblePlaybookOptions** object has those parameters described on `Options` section within ansible-playbook's man page, and which defines how should be the `ansible-playbook` execution behavior and where to find execution configuration
-- **AnsiblePlaybookConnectionOptions** object has those parameters described on `Connections Options` section within ansible-playbook's man page, and which defines how to connect to hosts.
+- **PlaybookCmd** object is the main object which defines the `ansible-playbook` command and how to execute it.
+- **PlaybookOptions** object has those parameters described on `Options` section within ansible-playbook's man page, and which defines how should be the `ansible-playbook` execution behavior and where to find execution configuration
+- **PlaybookConnectionOptions** object has those parameters described on `Connections Options` section within ansible-playbook's man page, and which defines how to connect to hosts.
 
 ## Executor
 Go-ansible package has its own and default executor implementation which runs the `ansible-playbook`command and prints its output with a prefix on each line.
-Whenever is required, you could write your own executor implementation and set it on `AnsiblePlaybookCmd` object, it will expect that the executor implements `Executor` interface.
+Whenever is required, you could write your own executor implementation and set it on `PlaybookCmd` object, it will expect that the executor implements `Executor` interface.
 ```go
 type Executor interface {
 	Execute(command string, args []string, prefix string) error
 }
 ```
 
-Its possible to define your own executor and set it on `AnsiblePlaybookCmd`.
+Its possible to define your own executor and set it on `PlaybookCmd`.
 ```go
 type MyExecutor struct {}
 func (e *MyExecutor) Execute(command string, args []string, prefix string) error {
@@ -26,7 +26,7 @@ func (e *MyExecutor) Execute(command string, args []string, prefix string) error
     return nil
 }
 
-playbook := &ansibler.AnsiblePlaybookCmd{
+playbook := &ansibler.PlaybookCmd{
     Playbook:          "site.yml",
     ConnectionOptions: ansiblePlaybookConnectionOptions,
     Options:           ansiblePlaybookOptions,
@@ -43,26 +43,26 @@ I am doing nothing
 
 ## Example
 
-When is needed to run an `ansible-playbook` from your Golang application using `go-ansible` package, you must define a `AnsiblePlaybookCmd`,`AnsiblePlaybookOptions`, `AnsiblePlaybookConnectionOptions` as its shown below.
+When is needed to run an `ansible-playbook` from your Golang application using `go-ansible` package, you must define a `PlaybookCmd`,`PlaybookOptions`, `PlaybookConnectionOptions` as its shown below.
 
 
-`AnsiblePlaybookConnectionOptions` where is defined how to connect to hosts.
+`PlaybookConnectionOptions` where is defined how to connect to hosts.
 ```go
-ansiblePlaybookConnectionOptions := &ansibler.AnsiblePlaybookConnectionOptions{
+ansiblePlaybookConnectionOptions := &ansibler.PlaybookConnectionOptions{
 	Connection: "local",
 }
 ```
 
-`AnsiblePlaybookOptions` where is defined which should be the `ansible-playbook` execution behavior and where to find execution configuration.
+`PlaybookOptions` where is defined which should be the `ansible-playbook` execution behavior and where to find execution configuration.
 ```go
-ansiblePlaybookOptions := &ansibler.AnsiblePlaybookOptions{
+ansiblePlaybookOptions := &ansibler.PlaybookOptions{
     Inventory: "127.0.0.1,",
 }
 ```
 
-`AnsiblePlaybookCmd` where is defined the command execution.
+`PlaybookCmd` where is defined the command execution.
 ```go
-playbook := &ansibler.AnsiblePlaybookCmd{
+playbook := &ansibler.PlaybookCmd{
     Playbook:          "site.yml",
     ConnectionOptions: ansiblePlaybookConnectionOptions,
     Options:           ansiblePlaybookOptions,
@@ -70,7 +70,7 @@ playbook := &ansibler.AnsiblePlaybookCmd{
 }
 ```
 
-Once the `AnsiblePlaybookCmd` is already defined it could be run it using the `Run` method.
+Once the `PlaybookCmd` is already defined it could be run it using the `Run` method.
 ```go
 err := playbook.Run()
 if err != nil {

--- a/ansiblePlaybook.go
+++ b/ansiblePlaybook.go
@@ -108,19 +108,22 @@ func AnsibleForceColor() {
 // Run method runs the ansible-playbook
 func (p *PlaybookCmd) Run() (PlaybookResults,error) {
 	if p == nil {
-		return nil,errors.New("(ansible:Run) PlaybookCmd is nil")
+		r := &PlaybookResults{}
+		return r,errors.New("(ansible:Run) PlaybookCmd is nil")
 	}
 
 	// Generate the command to be run
 	cmd, err := p.Command()
 	if err != nil {
-		return nil,errors.New("(ansible:Run) -> " + err.Error())
+		r := &PlaybookResults{}
+		return r,errors.New("(ansible:Run) -> " + err.Error())
 	}
 
 	err = p.Exec.Execute(cmd[0], cmd[1:])
 
 	if p.Exec.Stdout == "" {
-		return nil,errors.New("(ansible:Run) -> no stdout returned from playbook run")
+		r := &PlaybookResults{}
+		return r,errors.New("(ansible:Run) -> no stdout returned from playbook run")
 	}
 
 	r := &PlaybookResults{}

--- a/ansiblePlaybook.go
+++ b/ansiblePlaybook.go
@@ -106,7 +106,7 @@ func AnsibleForceColor() {
 }
 
 // Run method runs the ansible-playbook
-func (p *PlaybookCmd) Run() (*PlaybookResults,error) {
+func (p *PlaybookCmd) Run() (PlaybookResults,error) {
 	if p == nil {
 		return nil,errors.New("(ansible:Run) PlaybookCmd is nil")
 	}

--- a/ansiblePlaybook.go
+++ b/ansiblePlaybook.go
@@ -2,7 +2,6 @@ package ansibler
 
 import (
 	"errors"
-	"fmt"
 	"github.com/tidwall/gjson"
 	"os"
 	common "github.com/apenella/go-common-utils/data"
@@ -107,7 +106,7 @@ func AnsibleForceColor() {
 }
 
 // Run method runs the ansible-playbook
-func (p *PlaybookCmd) Run() (*PlaybookResults ,error) {
+func (p *PlaybookCmd) Run() (*PlaybookResults,error) {
 	if p == nil {
 		return nil,errors.New("(ansible:Run) PlaybookCmd is nil")
 	}
@@ -120,7 +119,6 @@ func (p *PlaybookCmd) Run() (*PlaybookResults ,error) {
 
 	err = p.Exec.Execute(cmd[0], cmd[1:])
 
-	fmt.Println(p.Exec.Stdout)
 	if p.Exec.Stdout == "" {
 		return nil,errors.New("(ansible:Run) -> no stdout returned from playbook run")
 	}
@@ -321,7 +319,10 @@ func (r *PlaybookResults) AnsibleJsonParse(e Executor) error {
 }
 
 // PlaybookResultsChecks return a error if a critical issue is found in playbook stats
-func (r *PlaybookResults) PlaybookResultsChecks(e Executor) error {
+func (r *PlaybookResults) PlaybookResultsChecks() error {
+	if r == nil {
+		return errors.New("(ansible:PlaybookResultsChecks) -> passed result is nil")
+	}
 	if r.Unreachable > 0 {
 		return errors.New("(ansible:Run) -> host is not reachable")
 	}

--- a/ansiblePlaybook.go
+++ b/ansiblePlaybook.go
@@ -107,9 +107,7 @@ func (p *AnsiblePlaybookCmd) Run() error {
 
 	// Define a default executor when it is not defined on AnsiblePlaybookCmd
 	if p.Exec == nil {
-		p.Exec = &DefaultExecute{
-			Write: p.Writer,
-		}
+		p.Exec = &DefaultExecute{}
 	}
 
 	// Generate the command to be run

--- a/ansiblePlaybook.go
+++ b/ansiblePlaybook.go
@@ -106,24 +106,21 @@ func AnsibleForceColor() {
 }
 
 // Run method runs the ansible-playbook
-func (p *PlaybookCmd) Run() (PlaybookResults,error) {
+func (p *PlaybookCmd) Run() (*PlaybookResults,error) {
 	if p == nil {
-		r := &PlaybookResults{}
-		return r,errors.New("(ansible:Run) PlaybookCmd is nil")
+		return nil,errors.New("(ansible:Run) PlaybookCmd is nil")
 	}
 
 	// Generate the command to be run
 	cmd, err := p.Command()
 	if err != nil {
-		r := &PlaybookResults{}
-		return r,errors.New("(ansible:Run) -> " + err.Error())
+		return nil,errors.New("(ansible:Run) -> " + err.Error())
 	}
 
 	err = p.Exec.Execute(cmd[0], cmd[1:])
 
 	if p.Exec.Stdout == "" {
-		r := &PlaybookResults{}
-		return r,errors.New("(ansible:Run) -> no stdout returned from playbook run")
+		return nil,errors.New("(ansible:Run) -> no stdout returned from playbook run")
 	}
 
 	r := &PlaybookResults{}

--- a/ansiblePlaybook.go
+++ b/ansiblePlaybook.go
@@ -49,22 +49,22 @@ const (
 	AnsibleForceColorEnv = "ANSIBLE_FORCE_COLOR"
 )
 
-// AnsiblePlaybookCmd object is the main object which defines the `ansible-playbook` command and how to execute it.
-type AnsiblePlaybookCmd struct {
+// PlaybookCmd object is the main object which defines the `ansible-playbook` command and how to execute it.
+type PlaybookCmd struct {
 	// Exec is the executor item
 	Exec Executor
 	// Playbook is the ansible's playbook name to be used
 	Playbook string
 	// Options are the ansible's playbook options
-	Options *AnsiblePlaybookOptions
+	Options *PlaybookOptions
 	// ConnectionOptions are the ansible's playbook specific options for connection
-	ConnectionOptions *AnsiblePlaybookConnectionOptions
+	ConnectionOptions *PlaybookConnectionOptions
 	// Writer manages the output
-	Res AnsiblePlaybookResults
+	Res PlaybookResults
 }
 
-// AnsiblePlaybookOptions object has those parameters described on `Options` section within ansible-playbook's man page, and which defines which should be the ansible-playbook execution behavior.
-type AnsiblePlaybookOptions struct {
+// PlaybookOptions object has those parameters described on `Options` section within ansible-playbook's man page, and which defines which should be the ansible-playbook execution behavior.
+type PlaybookOptions struct {
 	// ExtraVars is a map of extra variables used on ansible-playbook execution
 	ExtraVars map[string]interface{}
 	// FlushCache clear the fact cache for every host in inventory
@@ -83,13 +83,13 @@ type AnsiblePlaybookOptions struct {
 	Tags string
 }
 
-// AnsiblePlaybookConnectionOptions object has those parameters described on `Connections Options` section within ansible-playbook's man page, and which defines how to connect to hosts.
-type AnsiblePlaybookConnectionOptions struct {
+// PlaybookConnectionOptions object has those parameters described on `Connections Options` section within ansible-playbook's man page, and which defines how to connect to hosts.
+type PlaybookConnectionOptions struct {
 	// Connection is the type of connection used by ansible-playbook
 	Connection string
 }
 
-type AnsiblePlaybookResults struct {
+type PlaybookResults struct {
 	Stdout string
 	TimeElapsed string
 }
@@ -100,9 +100,9 @@ func AnsibleForceColor() {
 }
 
 // Run method runs the ansible-playbook
-func (p *AnsiblePlaybookCmd) Run() error {
+func (p *PlaybookCmd) Run() error {
 	if p == nil {
-		return errors.New("(ansible:Run) AnsiblePlaybookCmd is nil")
+		return errors.New("(ansible:Run) PlaybookCmd is nil")
 	}
 
 	// Generate the command to be run
@@ -120,7 +120,7 @@ func (p *AnsiblePlaybookCmd) Run() error {
 }
 
 // Command generate the ansible-playbook command which will be executed
-func (p *AnsiblePlaybookCmd) Command() ([]string, error) {
+func (p *PlaybookCmd) Command() ([]string, error) {
 	cmd := []string{}
 	// Set the ansible-playbook binary file
 	cmd = append(cmd, AnsiblePlaybookBin)
@@ -154,11 +154,11 @@ func (p *AnsiblePlaybookCmd) Command() ([]string, error) {
 }
 
 // GenerateCommandOptions return a list of options flags to be used on ansible-playbook execution
-func (o *AnsiblePlaybookOptions) GenerateCommandOptions() ([]string, error) {
+func (o *PlaybookOptions) GenerateCommandOptions() ([]string, error) {
 	cmd := []string{}
 
 	if o == nil {
-		return nil, errors.New("(ansible::GenerateCommandOptions) AnsiblePlaybookOptions is nil")
+		return nil, errors.New("(ansible::GenerateCommandOptions) PlaybookOptions is nil")
 	}
 
 	if o.FlushCache {
@@ -205,7 +205,7 @@ func (o *AnsiblePlaybookOptions) GenerateCommandOptions() ([]string, error) {
 }
 
 // generateExtraVarsCommand return an string which is a json structure having all the extra variable
-func (o *AnsiblePlaybookOptions) generateExtraVarsCommand() (string, error) {
+func (o *PlaybookOptions) generateExtraVarsCommand() (string, error) {
 
 	extraVars, err := common.ObjectToJSONString(o.ExtraVars)
 	if err != nil {
@@ -215,7 +215,7 @@ func (o *AnsiblePlaybookOptions) generateExtraVarsCommand() (string, error) {
 }
 
 // AddExtraVar registers a new extra variable on ansible-playbook options item
-func (o *AnsiblePlaybookOptions) AddExtraVar(name string, value interface{}) error {
+func (o *PlaybookOptions) AddExtraVar(name string, value interface{}) error {
 
 	if o.ExtraVars == nil {
 		o.ExtraVars = map[string]interface{}{}
@@ -231,7 +231,7 @@ func (o *AnsiblePlaybookOptions) AddExtraVar(name string, value interface{}) err
 }
 
 // GenerateCommandConnectionOptions return a list of connection options flags to be used on ansible-playbook execution
-func (o *AnsiblePlaybookConnectionOptions) GenerateCommandConnectionOptions() ([]string, error) {
+func (o *PlaybookConnectionOptions) GenerateCommandConnectionOptions() ([]string, error) {
 	cmd := []string{}
 
 	if o.Connection != "" {

--- a/ansiblePlaybook.go
+++ b/ansiblePlaybook.go
@@ -107,29 +107,29 @@ func AnsibleForceColor() {
 }
 
 // Run method runs the ansible-playbook
-func (p *PlaybookCmd) Run() error {
+func (p *PlaybookCmd) Run() (*PlaybookResults ,error) {
 	if p == nil {
-		return errors.New("(ansible:Run) PlaybookCmd is nil")
+		return nil,errors.New("(ansible:Run) PlaybookCmd is nil")
 	}
 
 	// Generate the command to be run
 	cmd, err := p.Command()
 	if err != nil {
-		return errors.New("(ansible:Run) -> " + err.Error())
+		return nil,errors.New("(ansible:Run) -> " + err.Error())
 	}
 
 	err = p.Exec.Execute(cmd[0], cmd[1:])
 
 	fmt.Println(p.Exec.Stdout)
 	if p.Exec.Stdout == "" {
-		return errors.New("(ansible:Run) -> no stdout returned from playbook run")
+		return nil,errors.New("(ansible:Run) -> no stdout returned from playbook run")
 	}
 
 	r := &PlaybookResults{}
 	r.AnsibleJsonParse(p.Exec)
 
 	// Execute the command an return
-	return err
+	return r,err
 }
 
 // Command generate the ansible-playbook command which will be executed

--- a/ansiblePlaybook.go
+++ b/ansiblePlaybook.go
@@ -2,9 +2,8 @@ package ansibler
 
 import (
 	"errors"
-	"io"
+
 	"os"
-	"fmt"
 
 	common "github.com/apenella/go-common-utils/data"
 )
@@ -50,11 +49,6 @@ const (
 	AnsibleForceColorEnv = "ANSIBLE_FORCE_COLOR"
 )
 
-// Executor is and interface that should be implemented for those item which could run ansible playbooks
-type Executor interface {
-	Execute(command string, args []string) error
-}
-
 // AnsiblePlaybookCmd object is the main object which defines the `ansible-playbook` command and how to execute it.
 type AnsiblePlaybookCmd struct {
 	// Exec is the executor item
@@ -66,7 +60,7 @@ type AnsiblePlaybookCmd struct {
 	// ConnectionOptions are the ansible's playbook specific options for connection
 	ConnectionOptions *AnsiblePlaybookConnectionOptions
 	// Writer manages the output
-	Writer io.Writer
+	//Results *AnsiblePlaybookResults
 }
 
 // AnsiblePlaybookOptions object has those parameters described on `Options` section within ansible-playbook's man page, and which defines which should be the ansible-playbook execution behavior.
@@ -95,6 +89,11 @@ type AnsiblePlaybookConnectionOptions struct {
 	Connection string
 }
 
+type AnsiblePlaybookResults struct {
+	Stdout string
+	TimeElapsed string
+}
+
 // AnsibleForceColor change to a forced color mode
 func AnsibleForceColor() {
 	os.Setenv(AnsibleForceColorEnv, "true")
@@ -106,11 +105,6 @@ func (p *AnsiblePlaybookCmd) Run() error {
 		return errors.New("(ansible:Run) AnsiblePlaybookCmd is nil")
 	}
 
-	// Define a default executor when it is not defined on AnsiblePlaybookCmd
-	if p.Exec == nil {
-		p.Exec = &DefaultExecute{TimeElapsed:"",Stdout:"",}
-	}
-
 	// Generate the command to be run
 	cmd, err := p.Command()
 	if err != nil {
@@ -118,9 +112,8 @@ func (p *AnsiblePlaybookCmd) Run() error {
 	}
 
 	err = p.Exec.Execute(cmd[0], cmd[1:])
-	fmt.Printf("%+v", p.Exec)
-	//jsonOut := p.Exec.Stdout()
-	//timeElapsed := p.Exec.TimeElapsed()
+	//p.Res.Stdout = p.Exec.Stdout
+	//p.Res.TimeElapsed = p.Exec.TimeElapsed
 
 	// Execute the command an return
 	return err

--- a/ansiblePlaybook.go
+++ b/ansiblePlaybook.go
@@ -60,7 +60,7 @@ type AnsiblePlaybookCmd struct {
 	// ConnectionOptions are the ansible's playbook specific options for connection
 	ConnectionOptions *AnsiblePlaybookConnectionOptions
 	// Writer manages the output
-	//Results *AnsiblePlaybookResults
+	Res AnsiblePlaybookResults
 }
 
 // AnsiblePlaybookOptions object has those parameters described on `Options` section within ansible-playbook's man page, and which defines which should be the ansible-playbook execution behavior.
@@ -112,8 +112,8 @@ func (p *AnsiblePlaybookCmd) Run() error {
 	}
 
 	err = p.Exec.Execute(cmd[0], cmd[1:])
-	//p.Res.Stdout = p.Exec.Stdout
-	//p.Res.TimeElapsed = p.Exec.TimeElapsed
+	p.Res.Stdout = p.Exec.Stdout
+	p.Res.TimeElapsed = p.Exec.TimeElapsed
 
 	// Execute the command an return
 	return err

--- a/ansiblePlaybook.go
+++ b/ansiblePlaybook.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"fmt"
 
 	common "github.com/apenella/go-common-utils/data"
 )
@@ -107,7 +108,7 @@ func (p *AnsiblePlaybookCmd) Run() error {
 
 	// Define a default executor when it is not defined on AnsiblePlaybookCmd
 	if p.Exec == nil {
-		p.Exec = &DefaultExecute{}
+		p.Exec = &DefaultExecute{TimeElapsed:"",Stdout:"",}
 	}
 
 	// Generate the command to be run
@@ -116,8 +117,13 @@ func (p *AnsiblePlaybookCmd) Run() error {
 		return errors.New("(ansible:Run) -> " + err.Error())
 	}
 
+	err = p.Exec.Execute(cmd[0], cmd[1:])
+	fmt.Printf("%+v", p.Exec)
+	//jsonOut := p.Exec.Stdout()
+	//timeElapsed := p.Exec.TimeElapsed()
+
 	// Execute the command an return
-	return p.Exec.Execute(cmd[0], cmd[1:])
+	return err
 }
 
 // Command generate the ansible-playbook command which will be executed

--- a/ansiblePlaybook.go
+++ b/ansiblePlaybook.go
@@ -51,15 +51,13 @@ const (
 
 // Executor is and interface that should be implemented for those item which could run ansible playbooks
 type Executor interface {
-	Execute(command string, args []string, prefix string) error
+	Execute(command string, args []string) error
 }
 
 // AnsiblePlaybookCmd object is the main object which defines the `ansible-playbook` command and how to execute it.
 type AnsiblePlaybookCmd struct {
 	// Exec is the executor item
 	Exec Executor
-	// ExecPrefix is a text that is set at the beginning of each execution line
-	ExecPrefix string
 	// Playbook is the ansible's playbook name to be used
 	Playbook string
 	// Options are the ansible's playbook options
@@ -120,13 +118,8 @@ func (p *AnsiblePlaybookCmd) Run() error {
 		return errors.New("(ansible:Run) -> " + err.Error())
 	}
 
-	// Set default prefix
-	if len(p.ExecPrefix) <= 0 {
-		p.ExecPrefix = ""
-	}
-
 	// Execute the command an return
-	return p.Exec.Execute(cmd[0], cmd[1:], p.ExecPrefix)
+	return p.Exec.Execute(cmd[0], cmd[1:])
 }
 
 // Command generate the ansible-playbook command which will be executed

--- a/ansiblePlaybook_test.go
+++ b/ansiblePlaybook_test.go
@@ -346,7 +346,6 @@ func TestRun(t *testing.T) {
 		res := &PlaybookResults{}
 		res, err := test.ansiblePlaybookCmd.Run()
 		if err != nil && res!=nil && assert.Error(t, err) {
-			fmt.Println(res.Changed)
 			assert.Equal(t, test.err, err)
 		} else {
 			assert.Equal(t, test.res, w.String(), "Unexpected value")

--- a/ansiblePlaybook_test.go
+++ b/ansiblePlaybook_test.go
@@ -13,13 +13,13 @@ import (
 func TestGenerateCommandConnectionOptions(t *testing.T) {
 	tests := []struct {
 		desc                             string
-		ansiblePlaybookConnectionOptions *AnsiblePlaybookConnectionOptions
+		ansiblePlaybookConnectionOptions *PlaybookConnectionOptions
 		err                              error
 		options                          []string
 	}{
 		{
 			desc: "Testing generate connection options",
-			ansiblePlaybookConnectionOptions: &AnsiblePlaybookConnectionOptions{
+			ansiblePlaybookConnectionOptions: &PlaybookConnectionOptions{
 				Connection: "local",
 			},
 			err: nil,
@@ -48,25 +48,25 @@ func TestGenerateCommandConnectionOptions(t *testing.T) {
 func TestGenerateCommandOptions(t *testing.T) {
 	tests := []struct {
 		desc                   string
-		ansiblePlaybookOptions *AnsiblePlaybookOptions
+		ansiblePlaybookOptions *PlaybookOptions
 		err                    error
 		options                []string
 	}{
 		{
-			desc:                   "Testing nil AnsiblePlaybookOptions definition",
+			desc:                   "Testing nil PlaybookOptions definition",
 			ansiblePlaybookOptions: nil,
-			err:                    errors.New("(ansible::GenerateCommandOptions) AnsiblePlaybookOptions is nil"),
+			err:                    errors.New("(ansible::GenerateCommandOptions) PlaybookOptions is nil"),
 			options:                nil,
 		},
 		{
-			desc:                   "Testing an empty AnsiblePlaybookOptions definition",
-			ansiblePlaybookOptions: &AnsiblePlaybookOptions{},
+			desc:                   "Testing an empty PlaybookOptions definition",
+			ansiblePlaybookOptions: &PlaybookOptions{},
 			err:                    nil,
 			options:                []string{},
 		},
 		{
-			desc: "Testing AnsiblePlaybookOptions except extra vars",
-			ansiblePlaybookOptions: &AnsiblePlaybookOptions{
+			desc: "Testing PlaybookOptions except extra vars",
+			ansiblePlaybookOptions: &PlaybookOptions{
 				FlushCache: true,
 				Inventory:  "inventory",
 				Limit:      "limit",
@@ -79,8 +79,8 @@ func TestGenerateCommandOptions(t *testing.T) {
 			options: []string{"--flush-cache", "--inventory", "inventory", "--limit", "limit", "--list-hosts", "--list-tags", "--list-tasks", "--tags", "tags"},
 		},
 		{
-			desc: "Testing AnsiblePlaybookOptions with extra vars",
-			ansiblePlaybookOptions: &AnsiblePlaybookOptions{
+			desc: "Testing PlaybookOptions with extra vars",
+			ansiblePlaybookOptions: &PlaybookOptions{
 				ExtraVars: map[string]interface{}{
 					"extra": "var",
 				},
@@ -114,13 +114,13 @@ func TestGenerateExtraVarsCommand(t *testing.T) {
 
 	tests := []struct {
 		desc                   string
-		ansiblePlaybookOptions *AnsiblePlaybookOptions
+		ansiblePlaybookOptions *PlaybookOptions
 		err                    error
 		extravars              string
 	}{
 		{
 			desc: "Testing extra vars map[string]string",
-			ansiblePlaybookOptions: &AnsiblePlaybookOptions{
+			ansiblePlaybookOptions: &PlaybookOptions{
 				ExtraVars: map[string]interface{}{
 					"extra": "var",
 				},
@@ -130,7 +130,7 @@ func TestGenerateExtraVarsCommand(t *testing.T) {
 		},
 		{
 			desc: "Testing extra vars map[string]bool",
-			ansiblePlaybookOptions: &AnsiblePlaybookOptions{
+			ansiblePlaybookOptions: &PlaybookOptions{
 				ExtraVars: map[string]interface{}{
 					"extra": true,
 				},
@@ -140,7 +140,7 @@ func TestGenerateExtraVarsCommand(t *testing.T) {
 		},
 		{
 			desc: "Testing extra vars map[string]int",
-			ansiblePlaybookOptions: &AnsiblePlaybookOptions{
+			ansiblePlaybookOptions: &PlaybookOptions{
 				ExtraVars: map[string]interface{}{
 					"extra": 10,
 				},
@@ -150,7 +150,7 @@ func TestGenerateExtraVarsCommand(t *testing.T) {
 		},
 		{
 			desc: "Testing extra vars map[string][]string",
-			ansiblePlaybookOptions: &AnsiblePlaybookOptions{
+			ansiblePlaybookOptions: &PlaybookOptions{
 				ExtraVars: map[string]interface{}{
 					"extra": []string{"var"},
 				},
@@ -160,7 +160,7 @@ func TestGenerateExtraVarsCommand(t *testing.T) {
 		},
 		{
 			desc: "Testing extra vars map[string]map[string]string",
-			ansiblePlaybookOptions: &AnsiblePlaybookOptions{
+			ansiblePlaybookOptions: &PlaybookOptions{
 				ExtraVars: map[string]interface{}{
 					"extra": map[string]string{
 						"var": "value",
@@ -188,7 +188,7 @@ func TestGenerateExtraVarsCommand(t *testing.T) {
 func TestAddExtraVar(t *testing.T) {
 	tests := []struct {
 		desc                   string
-		ansiblePlaybookOptions *AnsiblePlaybookOptions
+		ansiblePlaybookOptions *PlaybookOptions
 		err                    error
 		extraVarName           string
 		extraVarValue          interface{}
@@ -196,7 +196,7 @@ func TestAddExtraVar(t *testing.T) {
 	}{
 		{
 			desc: "Testing add an extraVar to a nil data structure",
-			ansiblePlaybookOptions: &AnsiblePlaybookOptions{
+			ansiblePlaybookOptions: &PlaybookOptions{
 				ExtraVars: nil,
 			},
 			err:           nil,
@@ -208,7 +208,7 @@ func TestAddExtraVar(t *testing.T) {
 		},
 		{
 			desc: "Testing add an extraVar",
-			ansiblePlaybookOptions: &AnsiblePlaybookOptions{
+			ansiblePlaybookOptions: &PlaybookOptions{
 				ExtraVars: map[string]interface{}{
 					"extra1": "var1",
 				},
@@ -223,7 +223,7 @@ func TestAddExtraVar(t *testing.T) {
 		},
 		{
 			desc: "Testing add an existing extraVar",
-			ansiblePlaybookOptions: &AnsiblePlaybookOptions{
+			ansiblePlaybookOptions: &PlaybookOptions{
 				ExtraVars: map[string]interface{}{
 					"extra": "var",
 				},
@@ -254,18 +254,18 @@ func TestCommand(t *testing.T) {
 	tests := []struct {
 		desc               string
 		err                error
-		ansiblePlaybookCmd *AnsiblePlaybookCmd
+		ansiblePlaybookCmd *PlaybookCmd
 		command            []string
 	}{
 		{
 			desc: "",
 			err:  nil,
-			ansiblePlaybookCmd: &AnsiblePlaybookCmd{
+			ansiblePlaybookCmd: &PlaybookCmd{
 				Playbook: "test/ansible/site.yml",
-				ConnectionOptions: &AnsiblePlaybookConnectionOptions{
+				ConnectionOptions: &PlaybookConnectionOptions{
 					Connection: "local",
 				},
-				Options: &AnsiblePlaybookOptions{
+				Options: &PlaybookOptions{
 					Inventory: "test/ansible/inventory/all",
 				},
 			},
@@ -298,7 +298,7 @@ func TestRun(t *testing.T) {
 
 	tests := []struct {
 		desc               string
-		ansiblePlaybookCmd *AnsiblePlaybookCmd
+		ansiblePlaybookCmd *PlaybookCmd
 		res                string
 		err                error
 	}{
@@ -306,16 +306,16 @@ func TestRun(t *testing.T) {
 			desc:               "Run nil ansiblePlaybookCmd",
 			ansiblePlaybookCmd: nil,
 			res:                "",
-			err:                errors.New("(ansible:Run) AnsiblePlaybookCmd is nil"),
+			err:                errors.New("(ansible:Run) PlaybookCmd is nil"),
 		},
 		{
 			desc: "Run a ansiblePlaybookCmd",
-			ansiblePlaybookCmd: &AnsiblePlaybookCmd{
+			ansiblePlaybookCmd: &PlaybookCmd{
 				Playbook: "test/test_site.yml",
-				ConnectionOptions: &AnsiblePlaybookConnectionOptions{
+				ConnectionOptions: &PlaybookConnectionOptions{
 					Connection: "local",
 				},
-				Options: &AnsiblePlaybookOptions{
+				Options: &PlaybookOptions{
 					Inventory: "test/ansible/inventory/all",
 				},
 			},
@@ -324,12 +324,12 @@ func TestRun(t *testing.T) {
 		},
 		{
 			desc: "Run a ansiblePlaybookCmd without executor",
-			ansiblePlaybookCmd: &AnsiblePlaybookCmd{
+			ansiblePlaybookCmd: &PlaybookCmd{
 				Playbook: "test/test_site.yml",
-				ConnectionOptions: &AnsiblePlaybookConnectionOptions{
+				ConnectionOptions: &PlaybookConnectionOptions{
 					Connection: "local",
 				},
-				Options: &AnsiblePlaybookOptions{
+				Options: &PlaybookOptions{
 					Inventory: "test/all",
 				},
 			},

--- a/ansiblePlaybook_test.go
+++ b/ansiblePlaybook_test.go
@@ -311,10 +311,7 @@ func TestRun(t *testing.T) {
 		{
 			desc: "Run a ansiblePlaybookCmd",
 			ansiblePlaybookCmd: &AnsiblePlaybookCmd{
-				Exec: &MockExecute{
-					Write: &w,
-				},
-				Playbook: "test/ansible/site.yml",
+				Playbook: "test/test_site.yml",
 				ConnectionOptions: &AnsiblePlaybookConnectionOptions{
 					Connection: "local",
 				},
@@ -322,13 +319,12 @@ func TestRun(t *testing.T) {
 					Inventory: "test/ansible/inventory/all",
 				},
 			},
-			res: "ansible-playbook [--inventory test/ansible/inventory/all --connection local test/ansible/site.yml]",
+			res: "",
 			err: nil,
 		},
 		{
 			desc: "Run a ansiblePlaybookCmd without executor",
 			ansiblePlaybookCmd: &AnsiblePlaybookCmd{
-				Exec:     nil,
 				Playbook: "test/test_site.yml",
 				ConnectionOptions: &AnsiblePlaybookConnectionOptions{
 					Connection: "local",

--- a/ansiblePlaybook_test.go
+++ b/ansiblePlaybook_test.go
@@ -3,6 +3,7 @@ package ansibler
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 
@@ -342,9 +343,10 @@ func TestRun(t *testing.T) {
 		w = bytes.Buffer{}
 
 		t.Log(test.desc)
-
-		err := test.ansiblePlaybookCmd.Run()
-		if err != nil && assert.Error(t, err) {
+		res := &PlaybookResults{}
+		res, err := test.ansiblePlaybookCmd.Run()
+		if err != nil && res!=nil && assert.Error(t, err) {
+			fmt.Println(res.Changed)
 			assert.Equal(t, test.err, err)
 		} else {
 			assert.Equal(t, test.res, w.String(), "Unexpected value")

--- a/ansible_test.go
+++ b/ansible_test.go
@@ -30,8 +30,10 @@ func TestAnsible(t *testing.T) {
 
 	res := &PlaybookResults{}
 	res, err := playbook.Run()
-	fmt.Println(res.Changed)
+	err = res.PlaybookResultsChecks()
 	if err != nil && assert.Error(t, err) {
 		assert.Equal(t, nil, err)
 	}
+	fmt.Println(res.Changed)
+
 }

--- a/ansible_test.go
+++ b/ansible_test.go
@@ -8,12 +8,12 @@ import (
 
 func TestAnsible(t *testing.T) {
 
-	playbook := &AnsiblePlaybookCmd{
+	playbook := &PlaybookCmd{
 		Playbook: "test/test_site.yml",
-		ConnectionOptions: &AnsiblePlaybookConnectionOptions{
+		ConnectionOptions: &PlaybookConnectionOptions{
 			Connection: "local",
 		},
-		Options: &AnsiblePlaybookOptions{
+		Options: &PlaybookOptions{
 			Inventory: "test/all",
 			ExtraVars: map[string]interface{}{
 				"string": "testing an string",

--- a/ansible_test.go
+++ b/ansible_test.go
@@ -2,7 +2,7 @@ package ansibler
 
 import (
 	"testing"
-
+	"fmt"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,8 +28,10 @@ func TestAnsible(t *testing.T) {
 		},
 	}
 
-	err := playbook.Run()
+	res := &PlaybookResults{}
+	res, err := playbook.Run()
 	if err != nil && assert.Error(t, err) {
+		fmt.Println(res.Changed)
 		assert.Equal(t, nil, err)
 	}
 }

--- a/ansible_test.go
+++ b/ansible_test.go
@@ -30,8 +30,8 @@ func TestAnsible(t *testing.T) {
 
 	res := &PlaybookResults{}
 	res, err := playbook.Run()
+	fmt.Println(res.Changed)
 	if err != nil && assert.Error(t, err) {
-		fmt.Println(res.Changed)
 		assert.Equal(t, nil, err)
 	}
 }

--- a/defaultExecute.go
+++ b/defaultExecute.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	//"time"
@@ -13,7 +12,7 @@ import (
 
 // DefaultExecute is a simple definition of an executor
 type DefaultExecute struct {
-	Write io.Writer
+	timeElapsed string
 }
 
 // Execute takes a command and args and runs it, streaming output to stdout

--- a/defaultExecute.go
+++ b/defaultExecute.go
@@ -4,15 +4,15 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
-	//"time"
+	"time"
 )
 
 // DefaultExecute is a simple definition of an executor
 type DefaultExecute struct {
-	timeElapsed string
+	TimeElapsed string
+	Stdout string
 }
 
 // Execute takes a command and args and runs it, streaming output to stdout
@@ -39,20 +39,19 @@ func (e *DefaultExecute) Execute(command string, args []string) error {
 		}
 	}()
 
-	//timeInit := time.Now()
+	timeInit := time.Now()
 	err = cmd.Start()
 	if err != nil {
 		return errors.New("(DefaultExecute::Execute) -> " + err.Error())
 	}
 
 	err = cmd.Wait()
-	//elapsedTime := time.Since(timeInit)
 	if err != nil {
 		return errors.New("(DefaultExecute::Execute) -> " + stderr.String())
 	}
 
-	//fmt.Fprintf(e.Write, "Duration: %s\n", elapsedTime.String())
-	fmt.Println(stdBuf)
+	e.TimeElapsed = time.Since(timeInit).String()
+	e.Stdout = stdBuf
 
 	return nil
 }

--- a/defaultExecute.go
+++ b/defaultExecute.go
@@ -10,13 +10,13 @@ import (
 )
 
 // DefaultExecute is a simple definition of an executor
-type DefaultExecute struct {
+type Executor struct {
 	TimeElapsed string
 	Stdout string
 }
 
 // Execute takes a command and args and runs it, streaming output to stdout
-func (e *DefaultExecute) Execute(command string, args []string) error {
+func (e *Executor) Execute(command string, args []string) error {
 
 	var stdBuf string
 	stderr := &bytes.Buffer{}

--- a/defaultExecute.go
+++ b/defaultExecute.go
@@ -19,11 +19,8 @@ type DefaultExecute struct {
 // Execute takes a command and args and runs it, streaming output to stdout
 func (e *DefaultExecute) Execute(command string, args []string) error {
 
+	var stdBuf string
 	stderr := &bytes.Buffer{}
-
-	if e.Write == nil {
-		e.Write = os.Stdout
-	}
 
 	cmd := exec.Command(command, args...)
 	cmd.Env = os.Environ()
@@ -39,7 +36,7 @@ func (e *DefaultExecute) Execute(command string, args []string) error {
 	scanner := bufio.NewScanner(cmdReader)
 	go func() {
 		for scanner.Scan() {
-			fmt.Fprintf(e.Write, "%s\n",scanner.Text())
+			stdBuf = stdBuf +"\n"+ scanner.Text()
 		}
 	}()
 
@@ -56,6 +53,7 @@ func (e *DefaultExecute) Execute(command string, args []string) error {
 	}
 
 	//fmt.Fprintf(e.Write, "Duration: %s\n", elapsedTime.String())
+	fmt.Println(stdBuf)
 
 	return nil
 }

--- a/defaultExecute.go
+++ b/defaultExecute.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"time"
+	//"time"
 )
 
 // DefaultExecute is a simple definition of an executor
@@ -17,7 +17,7 @@ type DefaultExecute struct {
 }
 
 // Execute takes a command and args and runs it, streaming output to stdout
-func (e *DefaultExecute) Execute(command string, args []string, prefix string) error {
+func (e *DefaultExecute) Execute(command string, args []string) error {
 
 	stderr := &bytes.Buffer{}
 
@@ -26,6 +26,9 @@ func (e *DefaultExecute) Execute(command string, args []string, prefix string) e
 	}
 
 	cmd := exec.Command(command, args...)
+	cmd.Env = os.Environ()
+    cmd.Env = append(cmd.Env, "ANSIBLE_STDOUT_CALLBACK=json")
+    cmd.Env = append(cmd.Env, "ANSIBLE_HOST_KEY_CHECKING=False")
 	cmd.Stderr = stderr
 
 	cmdReader, err := cmd.StdoutPipe()
@@ -36,23 +39,23 @@ func (e *DefaultExecute) Execute(command string, args []string, prefix string) e
 	scanner := bufio.NewScanner(cmdReader)
 	go func() {
 		for scanner.Scan() {
-			fmt.Fprintf(e.Write, "%s =>  %s\n", prefix, scanner.Text())
+			fmt.Fprintf(e.Write, "%s\n",scanner.Text())
 		}
 	}()
 
-	timeInit := time.Now()
+	//timeInit := time.Now()
 	err = cmd.Start()
 	if err != nil {
 		return errors.New("(DefaultExecute::Execute) -> " + err.Error())
 	}
 
 	err = cmd.Wait()
-	elapsedTime := time.Since(timeInit)
+	//elapsedTime := time.Since(timeInit)
 	if err != nil {
 		return errors.New("(DefaultExecute::Execute) -> " + stderr.String())
 	}
 
-	fmt.Fprintf(e.Write, "Duration: %s\n", elapsedTime.String())
+	//fmt.Fprintf(e.Write, "Duration: %s\n", elapsedTime.String())
 
 	return nil
 }

--- a/defaultExecute_test.go
+++ b/defaultExecute_test.go
@@ -13,7 +13,6 @@ func TestDefaultExecute(t *testing.T) {
 		err     error
 		execute *DefaultExecute
 		command []string
-		prefix  string
 		res     string
 	}{
 		{
@@ -23,14 +22,13 @@ func TestDefaultExecute(t *testing.T) {
 				Write: os.Stdout,
 			},
 			command: []string{"echo", "hello"},
-			prefix:  "test",
 		},
 	}
 
 	for _, test := range tests {
 		t.Log(test.desc)
 
-		err := test.execute.Execute(test.command[0], test.command[1:], test.prefix)
+		err := test.execute.Execute(test.command[0], test.command[1:])
 		if err != nil && assert.Error(t, err) {
 			assert.Equal(t, test.err, err)
 		}

--- a/defaultExecute_test.go
+++ b/defaultExecute_test.go
@@ -1,7 +1,6 @@
 package ansibler
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,9 +17,7 @@ func TestDefaultExecute(t *testing.T) {
 		{
 			desc: "Testing an execution",
 			err:  nil,
-			execute: &DefaultExecute{
-				Write: os.Stdout,
-			},
+			execute: &DefaultExecute{},
 			command: []string{"echo", "hello"},
 		},
 	}

--- a/defaultExecute_test.go
+++ b/defaultExecute_test.go
@@ -10,14 +10,14 @@ func TestDefaultExecute(t *testing.T) {
 	tests := []struct {
 		desc    string
 		err     error
-		execute *DefaultExecute
+		execute *Executor
 		command []string
 		res     string
 	}{
 		{
 			desc: "Testing an execution",
 			err:  nil,
-			execute: &DefaultExecute{},
+			execute: &Executor{},
 			command: []string{"echo", "hello"},
 		},
 	}

--- a/examples/cobra-cmd-ansibleplaybook/cobra-cmd-ansibleplaybook.go
+++ b/examples/cobra-cmd-ansibleplaybook/cobra-cmd-ansibleplaybook.go
@@ -52,12 +52,12 @@ func commandHandler(cmd *cobra.Command, args []string) error {
 		return errors.New("Error parsing extra variables. " + err.Error())
 	}
 
-	ansiblePlaybookConnectionOptions := &ansibler.AnsiblePlaybookConnectionOptions{}
+	ansiblePlaybookConnectionOptions := &ansibler.PlaybookConnectionOptions{}
 	if connectionLocal {
 		ansiblePlaybookConnectionOptions.Connection = "local"
 	}
 
-	ansiblePlaybookOptions := &ansibler.AnsiblePlaybookOptions{
+	ansiblePlaybookOptions := &ansibler.PlaybookOptions{
 		Inventory: inventory,
 	}
 
@@ -65,7 +65,7 @@ func commandHandler(cmd *cobra.Command, args []string) error {
 		ansiblePlaybookOptions.AddExtraVar(keyVar, valueVar)
 	}
 
-	playbook := &ansibler.AnsiblePlaybookCmd{
+	playbook := &ansibler.PlaybookCmd{
 		Playbook:          playbook,
 		ConnectionOptions: ansiblePlaybookConnectionOptions,
 		Options:           ansiblePlaybookOptions,

--- a/examples/myexecutor-ansibleplaybook/myexecutor-ansibleplaybook.go
+++ b/examples/myexecutor-ansibleplaybook/myexecutor-ansibleplaybook.go
@@ -16,15 +16,15 @@ func (e *MyExecutor) Execute(command string, args []string, prefix string) error
 
 func main() {
 
-	ansiblePlaybookConnectionOptions := &ansibler.AnsiblePlaybookConnectionOptions{
+	ansiblePlaybookConnectionOptions := &ansibler.PlaybookConnectionOptions{
 		Connection: "local",
 	}
 
-	ansiblePlaybookOptions := &ansibler.AnsiblePlaybookOptions{
+	ansiblePlaybookOptions := &ansibler.PlaybookOptions{
 		Inventory: "127.0.0.1,",
 	}
 
-	playbook := &ansibler.AnsiblePlaybookCmd{
+	playbook := &ansibler.PlaybookCmd{
 		Playbook:          "site.yml",
 		ConnectionOptions: ansiblePlaybookConnectionOptions,
 		Options:           ansiblePlaybookOptions,

--- a/examples/simple-ansibleplaybook/simple-ansibleplaybook.go
+++ b/examples/simple-ansibleplaybook/simple-ansibleplaybook.go
@@ -6,15 +6,15 @@ import (
 
 func main() {
 
-	ansiblePlaybookConnectionOptions := &ansibler.AnsiblePlaybookConnectionOptions{
+	ansiblePlaybookConnectionOptions := &ansibler.PlaybookConnectionOptions{
 		Connection: "local",
 	}
 
-	ansiblePlaybookOptions := &ansibler.AnsiblePlaybookOptions{
+	ansiblePlaybookOptions := &ansibler.PlaybookOptions{
 		Inventory: "127.0.0.1,",
 	}
 
-	playbook := &ansibler.AnsiblePlaybookCmd{
+	playbook := &ansibler.PlaybookCmd{
 		Playbook:          "site.yml",
 		ConnectionOptions: ansiblePlaybookConnectionOptions,
 		Options:           ansiblePlaybookOptions,

--- a/mockExecute.go
+++ b/mockExecute.go
@@ -13,7 +13,7 @@ type MockExecute struct {
 }
 
 // Execute takes a command and args and runs it, streaming output to stdout
-func (e *MockExecute) Execute(command string, args []string, prefix string) error {
+func (e *MockExecute) Execute(command string, args []string) error {
 	if e.Write == nil {
 		e.Write = os.Stdout
 	}

--- a/mockExecute_test.go
+++ b/mockExecute_test.go
@@ -13,7 +13,6 @@ func TestMockExecute(t *testing.T) {
 		err     error
 		execute *MockExecute
 		command []string
-		prefix  string
 		res     string
 	}{
 		{
@@ -21,7 +20,6 @@ func TestMockExecute(t *testing.T) {
 			err:     errors.New("(MockExecute::Execute) error"),
 			execute: &MockExecute{},
 			command: []string{"error"},
-			prefix:  "",
 			res:     "",
 		},
 		{
@@ -29,7 +27,6 @@ func TestMockExecute(t *testing.T) {
 			err:     nil,
 			execute: &MockExecute{},
 			command: []string{"command", "arg1", "arg2"},
-			prefix:  "prefix",
 			res:     "prefix command arg1 arg2",
 		},
 	}
@@ -37,7 +34,7 @@ func TestMockExecute(t *testing.T) {
 	for _, test := range tests {
 		t.Log(test.desc)
 
-		err := test.execute.Execute(test.command[0], test.command[1:], test.prefix)
+		err := test.execute.Execute(test.command[0], test.command[1:])
 		if err != nil && assert.Error(t, err) {
 			assert.Equal(t, test.err, err)
 		}

--- a/test/test_site.yml
+++ b/test/test_site.yml
@@ -1,9 +1,8 @@
 ---
 
 - hosts: local
+  gather_facts: no
 
   tasks:
     - name: Print line
-      debug:
-        msg: That's a message to debug
-
+      command: ping -c 4 8.8.8.8


### PR DESCRIPTION
Hi mate!

I've been using your library for a long time and after a while, by using it, I thought about possible improvements that you may find intresting...
As you can see in PR details, i added this in the Execute function
 cmd.Env = append(cmd.Env, "ANSIBLE_STDOUT_CALLBACK=json")
with this ansible will run returning a json as result.
the result is parsed and saved in a PlaybookResults object defined this way
`type PlaybookResults struct {
    RawStdout string //json output of the playbook run
    TimeElapsed string //time elapsed for the playbook run
    Changed  int64 //number of items changed
    Failures int64 //number of failures
    Ignored int64  // so on ...
    Ok int64
    Rescued int64
    Skipped int64
    Unreachable int64
}`
in this way users can grab ansible run information as well as stdout and use those informations, for example in conditions...

let me know what you think about it

keep rockin' on
Luca