### PR TITLE
fix bug ansible always showing error " error: unrecognized arguments"…

### DIFF
--- a/ansiblePlaybook.go
+++ b/ansiblePlaybook.go
@@ -52,7 +52,7 @@ const (
 	ListTasksFlag = "--list-tasks"
 
 	// PrivateKeyFlag is the private key file flag for ansible-playbook
-	PrivateKeyFlag = "--private-key "
+	PrivateKeyFlag = "--private-key"
 
 	// TagsFlag is the tags flag for ansible-playbook
 	TagsFlag = "--tags"


### PR DESCRIPTION
when using private key, ansible will show error: _**unrecognized arguments site.yaml**_,
turned out there was a blank space in private key command parameter, golang read the blank space as value for the parameter.