### PR TITLE
Add skipPatterns for Ansible warning

### DIFF
--- a/stdoutcallback/results/ansiblePlaybookJSONResults.go
+++ b/stdoutcallback/results/ansiblePlaybookJSONResults.go
@@ -161,6 +161,8 @@ func skipLine(line string) bool {
 	skipPatterns := []string{
 		// This pattern skips timer's callback whitelist output
 		"^[\\s\\t]*Playbook run took [0-9]+ days, [0-9]+ hours, [0-9]+ minutes, [0-9]+ seconds$",
+		"^\\[WARNING\\]:.+ use",
+		"^\\-vvvv",
 	}
 
 	for _, pattern := range skipPatterns {


### PR DESCRIPTION
I had an error from the json Unmarshal, Ansible warnings are not passed as JSON.

I had to add two exceptions since they were return as two separate lines.
