### PR TITLE
Add Ansible adhoc

### DIFF
--- a/ansible.go
+++ b/ansible.go
@@ -1,0 +1,257 @@
+package ansibler
+
+import (
+	"fmt"
+	"os"
+)
+
+// Binaries
+const (
+	// DefaultAnsiblePlaybookBinary is the ansible-playbook binary file default value
+	DefaultAnsiblePlaybookBinary = "ansible-playbook"
+
+	// DefaultAnsibleBinary is the ansible binary file default value
+	DefaultAnsibleBinary = "ansible"
+)
+
+// Optional arguments
+const (
+
+	// ExtraVarsFlag is the extra variables flag for ansible-playbook
+	ExtraVarsFlag = "--extra-vars"
+
+	// FlushCacheFlag is the flush cache flag for ansible-playbook
+	FlushCacheFlag = "--flush-cache"
+
+	// InventoryFlag is the inventory flag for ansible-playbook
+	InventoryFlag = "--inventory"
+
+	// LimitFlag is the limit flag for ansible-playbook
+	LimitFlag = "--limit"
+
+	// ListHostsFlag is the list hosts flag for ansible-playbook
+	ListHostsFlag = "--list-hosts"
+
+	// ListTagsFlag is the list tags flag for ansible-playbook
+	ListTagsFlag = "--list-tags"
+
+	// ListTasksFlag is the list tasks flag for ansible-playbook
+	ListTasksFlag = "--list-tasks"
+
+	// TagsFlag is the tags flag for ansible-playbook
+	TagsFlag = "--tags"
+
+	// SyntaxCheckFlag is the syntax check flag for ansible-playbook
+	SyntaxCheckFlag = "--syntax-check"
+
+	// VaultPasswordFileFlag is the vault password file flag for ansible-playbook
+	VaultPasswordFileFlag = "--vault-password-file"
+
+	// ansible configuration consts
+
+	// AnsibleForceColorEnv is the environment variable which forces color mode
+	AnsibleForceColorEnv = "ANSIBLE_FORCE_COLOR"
+
+	// AnsibleHostKeyCheckingEnv
+	AnsibleHostKeyCheckingEnv = "ANSIBLE_HOST_KEY_CHECKING"
+)
+
+// Connection Options
+const (
+	// PrivateKeyFlag is the private key file flag for ansible-playbook
+	PrivateKeyFlag = "--private-key"
+
+	// TimeoutFlag is the timeout flag for ansible-playbook
+	TimeoutFlag = "--timeout"
+
+	// ConnectionFlag is the connection flag for ansible-playbook
+	ConnectionFlag = "--connection"
+
+	// AskPassFlag is ansble-playbook's ask for connection password flag
+	AskPassFlag = "--ask-pass"
+
+	// UserFlag is the user flag for ansible-playbook
+	UserFlag = "--user"
+)
+
+// Privilege Escalation Options
+const (
+	// BecomeMethodFlag is ansble-playbook's become method flag
+	BecomeMethodFlag = "--become-method"
+
+	// BecomeUserFlag is ansble-playbook's become user flag
+	BecomeUserFlag = "--become-user"
+
+	// AskBecomePassFlag is ansble-playbook's ask for become user password flag
+	AskBecomePassFlag = "--ask-become-pass"
+
+	// BecomeFlag is ansble-playbook's become flag
+	BecomeFlag = "--become"
+)
+
+// Executor is and interface that should be implemented for those item which could run ansible playbooks
+type Executor interface {
+	Execute(command string, args []string, prefix string) error
+}
+
+// AnsibleForceColor changes to a forced color mode
+func AnsibleForceColor() {
+	os.Setenv(AnsibleForceColorEnv, "true")
+}
+
+// AnsibleAvoidHostKeyChecking sets the hosts key checking to false
+func AnsibleAvoidHostKeyChecking() {
+	os.Setenv(AnsibleHostKeyCheckingEnv, "false")
+}
+
+// AnsibleSetEnv set any configuration by environment variables. Check ansible configuration at https://docs.ansible.com/ansible/latest/reference_appendices/config.html
+func AnsibleSetEnv(key, value string) {
+	os.Setenv(key, value)
+}
+
+// AnsibleConnectionOptions object has those parameters described on `Connections Options` section within ansible-playbook's man page, and which defines how to connect to hosts.
+type AnsibleConnectionOptions struct {
+	// AskPass defines whether user's password should be asked to connect to host
+	AskPass bool
+	// Connection is the type of connection used by ansible-playbook
+	Connection string
+	// PrivateKey is the user's private key file used to connect to a host
+	PrivateKey string
+	// Timeout is the connection timeout on ansible-playbook. Take care because Timeout is defined ad string
+	Timeout string
+	// User is the user to use to connect to a host
+	User string
+}
+
+// GenerateCommandConnectionOptions return a list of connection options flags to be used on ansible-playbook execution
+func (o *AnsibleConnectionOptions) GenerateCommandConnectionOptions() ([]string, error) {
+	cmd := []string{}
+
+	if o.AskPass {
+		cmd = append(cmd, AskPassFlag)
+	}
+
+	if o.Connection != "" {
+		cmd = append(cmd, ConnectionFlag)
+		cmd = append(cmd, o.Connection)
+	}
+
+	if o.PrivateKey != "" {
+		cmd = append(cmd, PrivateKeyFlag)
+		cmd = append(cmd, o.PrivateKey)
+	}
+
+	if o.User != "" {
+		cmd = append(cmd, UserFlag)
+		cmd = append(cmd, o.User)
+	}
+
+	if o.Timeout != "" {
+		cmd = append(cmd, TimeoutFlag)
+		cmd = append(cmd, o.Timeout)
+	}
+
+	return cmd, nil
+}
+
+// String return a list of connection options flags to be used on ansible-playbook execution
+func (o *AnsibleConnectionOptions) String() string {
+	str := ""
+
+	if o.AskPass {
+		str = fmt.Sprintf("%s %s", str, AskPassFlag)
+	}
+
+	if o.Connection != "" {
+		str = fmt.Sprintf("%s %s %s", str, ConnectionFlag, o.Connection)
+	}
+
+	if o.PrivateKey != "" {
+		str = fmt.Sprintf("%s %s %s", str, PrivateKeyFlag, o.PrivateKey)
+	}
+
+	if o.User != "" {
+		str = fmt.Sprintf("%s %s %s", str, UserFlag, o.User)
+	}
+
+	if o.Timeout != "" {
+		str = fmt.Sprintf("%s %s %s", str, TimeoutFlag, o.Timeout)
+	}
+
+	return str
+}
+
+/* become methods
+ksu        Kerberos substitute user
+pbrun      PowerBroker run
+enable     Switch to elevated permissions on a network device
+sesu       CA Privileged Access Manager
+pmrun      Privilege Manager run
+runas      Run As user
+sudo       Substitute User DO
+su         Substitute User
+doas       Do As user
+pfexec     profile based execution
+machinectl Systemd's machinectl privilege escalation
+dzdo       Centrify's Direct Authorize
+*/
+
+// AnsiblePrivilegeEscalationOptions object has those parameters described on `Privilege Escalation Options` section within ansible-playbook's man page, and which controls how and which user you become as on target hosts.
+type AnsiblePrivilegeEscalationOptions struct {
+	// Become
+	Become bool
+	// BecomeMethod
+	BecomeMethod string
+	// BecomeUser
+	BecomeUser string
+	// AskBecomePass
+	AskBecomePass bool
+}
+
+// GenerateCommandPrivilegeEscalationOptions return a list of privilege escalation options flags to be used on ansible-playbook execution
+func (o *AnsiblePrivilegeEscalationOptions) GenerateCommandPrivilegeEscalationOptions() ([]string, error) {
+	cmd := []string{}
+
+	if o.AskBecomePass {
+		cmd = append(cmd, AskBecomePassFlag)
+	}
+
+	if o.Become {
+		cmd = append(cmd, BecomeFlag)
+	}
+
+	if o.BecomeMethod != "" {
+		cmd = append(cmd, BecomeMethodFlag)
+		cmd = append(cmd, o.BecomeMethod)
+	}
+
+	if o.BecomeUser != "" {
+		cmd = append(cmd, BecomeUserFlag)
+		cmd = append(cmd, o.BecomeUser)
+	}
+
+	return cmd, nil
+}
+
+// String return an string
+func (o *AnsiblePrivilegeEscalationOptions) String() string {
+	str := ""
+
+	if o.AskBecomePass {
+		str = fmt.Sprintf("%s %s", str, AskBecomePassFlag)
+	}
+
+	if o.Become {
+		str = fmt.Sprintf("%s %s", str, BecomeFlag)
+	}
+
+	if o.BecomeMethod != "" {
+		str = fmt.Sprintf("%s %s %s", str, BecomeMethodFlag, o.BecomeMethod)
+	}
+
+	if o.BecomeUser != "" {
+		str = fmt.Sprintf("%s %s %s", str, BecomeUserFlag, o.BecomeUser)
+	}
+
+	return str
+}

--- a/ansibleAdhoc.go
+++ b/ansibleAdhoc.go
@@ -2,27 +2,34 @@ package ansibler
 
 import (
 	"fmt"
-	"io"
-	"os/exec"
-
 	"github.com/apenella/go-ansible/execute"
 	"github.com/apenella/go-ansible/stdoutcallback"
 	common "github.com/apenella/go-common-utils/data"
 	errors "github.com/apenella/go-common-utils/error"
+	"io"
+	"os/exec"
 )
 
-// AnsiblePlaybookCmd object is the main object which defines the `ansible-playbook` command and how to execute it.
-type AnsiblePlaybookCmd struct {
+const (
+	// ModuleNameFlag is the module-name flag for ansible adhoc
+	ModuleNameFlag = "--module-name"
+
+	// ModuleArgsFlag is module argument flag ansible adhoc
+	ModuleArgsFlag = "--args"
+)
+
+// AnsibleAdhocCmd object is the main object which defines the `ansible` command and how to execute it.
+type AnsibleAdhocCmd struct {
 	// Ansible binary file
 	Binary string
 	// Exec is the executor item
 	Exec Executor
 	// ExecPrefix is a text that is set at the beginning of each execution line
 	ExecPrefix string
-	// Playbook is the ansible's playbook name to be used
-	Playbook string
+	// Pattern is the ansible's host patterns
+	Pattern string
 	// Options are the ansible's playbook options
-	Options *AnsiblePlaybookOptions
+	Options *AnsibleAdhocOptions
 	// ConnectionOptions are the ansible's playbook specific options for connection
 	ConnectionOptions *AnsibleConnectionOptions
 	// PrivilegeEscalationOptions are the ansible's playbook privilage escalation options
@@ -34,65 +41,65 @@ type AnsiblePlaybookCmd struct {
 }
 
 // Run method runs the ansible-playbook
-func (p *AnsiblePlaybookCmd) Run() error {
+func (a *AnsibleAdhocCmd) Run() error {
 	var err error
 	var cmd []string
 
-	if p == nil {
+	if a == nil {
 		return errors.New("(ansible:Run)", "AnsiblePlaybookCmd is nil")
 	}
 
 	// Use default binary when it is not already defined
-	if p.Binary == "" {
-		p.Binary = DefaultAnsiblePlaybookBinary
+	if a.Binary == "" {
+		a.Binary = DefaultAnsibleBinary
 	}
 
-	_, err = exec.LookPath(p.Binary)
+	_, err = exec.LookPath(a.Binary)
 	if err != nil {
-		return errors.New("(ansible:Run)", fmt.Sprintf("Binary file '%s' does not exists", p.Binary), err)
+		return errors.New("(ansible:Run)", fmt.Sprintf("Binary file '%s' does not exists", a.Binary), err)
 	}
 
-	// Define a default executor when it is not defined on AnsiblePlaybookCmd
-	if p.Exec == nil {
-		p.Exec = &execute.DefaultExecute{
-			Write:       p.Writer,
-			ResultsFunc: stdoutcallback.GetResultsFunc(p.StdoutCallback),
+	// Define a default executor when it is not defined on AnsibleAdhocCmd
+	if a.Exec == nil {
+		a.Exec = &execute.DefaultExecute{
+			Write:       a.Writer,
+			ResultsFunc: stdoutcallback.GetResultsFunc(a.StdoutCallback),
 		}
 	}
 
 	// Generate the command to be run
-	cmd, err = p.Command()
+	cmd, err = a.Command()
 	if err != nil {
-		return errors.New("(ansible:Run)", fmt.Sprintf("Error running '%s'", p.String()), err)
+		return errors.New("(ansible:Run)", fmt.Sprintf("Error running '%s'", a.String()), err)
 	}
 
 	// Set default prefix
-	if len(p.ExecPrefix) <= 0 {
-		p.ExecPrefix = ""
+	if len(a.ExecPrefix) <= 0 {
+		a.ExecPrefix = ""
 	}
 
 	// Configure StdoutCallback method. By default is used ansible's 'default' callback method
-	stdoutcallback.AnsibleStdoutCallbackSetEnv(p.StdoutCallback)
+	stdoutcallback.AnsibleStdoutCallbackSetEnv(a.StdoutCallback)
 
 	// Execute the command an return
-	return p.Exec.Execute(cmd[0], cmd[1:], p.ExecPrefix)
+	return a.Exec.Execute(cmd[0], cmd[1:], a.ExecPrefix)
 }
 
 // Command generate the ansible-playbook command which will be executed
-func (p *AnsiblePlaybookCmd) Command() ([]string, error) {
+func (a *AnsibleAdhocCmd) Command() ([]string, error) {
 	cmd := []string{}
 
 	// Use default binary when it is not already defined
-	if p.Binary == "" {
-		p.Binary = DefaultAnsiblePlaybookBinary
+	if a.Binary == "" {
+		a.Binary = DefaultAnsiblePlaybookBinary
 	}
 
 	// Set the ansible-playbook binary file
-	cmd = append(cmd, p.Binary)
+	cmd = append(cmd, a.Binary)
 
 	// Determine the options to be set
-	if p.Options != nil {
-		options, err := p.Options.GenerateCommandOptions()
+	if a.Options != nil {
+		options, err := a.Options.GenerateCommandOptions()
 		if err != nil {
 			return nil, errors.New("(ansible::Command)", "Error creating options", err)
 		}
@@ -102,8 +109,8 @@ func (p *AnsiblePlaybookCmd) Command() ([]string, error) {
 	}
 
 	// Determine the connection options to be set
-	if p.ConnectionOptions != nil {
-		options, err := p.ConnectionOptions.GenerateCommandConnectionOptions()
+	if a.ConnectionOptions != nil {
+		options, err := a.ConnectionOptions.GenerateCommandConnectionOptions()
 		if err != nil {
 			return nil, errors.New("(ansible::Command)", "Error creating connection options", err)
 		}
@@ -113,8 +120,8 @@ func (p *AnsiblePlaybookCmd) Command() ([]string, error) {
 	}
 
 	// Determine the privilege escalation options to be set
-	if p.PrivilegeEscalationOptions != nil {
-		options, err := p.PrivilegeEscalationOptions.GenerateCommandPrivilegeEscalationOptions()
+	if a.PrivilegeEscalationOptions != nil {
+		options, err := a.PrivilegeEscalationOptions.GenerateCommandPrivilegeEscalationOptions()
 		if err != nil {
 			return nil, errors.New("(ansible::Command)", "Error creating privilege escalation options", err)
 		}
@@ -123,18 +130,18 @@ func (p *AnsiblePlaybookCmd) Command() ([]string, error) {
 		}
 	}
 
-	// Include the ansible playbook
-	cmd = append(cmd, p.Playbook)
+	// Include the ansible host pattern
+	cmd = append(cmd, a.Pattern)
 
 	return cmd, nil
 }
 
-// String returns AnsiblePlaybookCmd as string
-func (p *AnsiblePlaybookCmd) String() string {
+// String returns AnsibleAdhocCmd as string
+func (p *AnsibleAdhocCmd) String() string {
 
 	// Use default binary when it is not already defined
 	if p.Binary == "" {
-		p.Binary = DefaultAnsiblePlaybookBinary
+		p.Binary = DefaultAnsibleBinary
 	}
 
 	str := p.Binary
@@ -149,43 +156,43 @@ func (p *AnsiblePlaybookCmd) String() string {
 		str = fmt.Sprintf("%s %s", str, p.PrivilegeEscalationOptions.String())
 	}
 
-	str = fmt.Sprintf("%s %s", str, p.Playbook)
+	str = fmt.Sprintf("%s %s", str, p.Pattern)
 
 	return str
 }
 
-// AnsiblePlaybookOptions object has those parameters described on `Options` section within ansible-playbook's man page, and which defines which should be the ansible-playbook execution behavior.
-type AnsiblePlaybookOptions struct {
+// AnsibleAdhocOptions object has those parameters described on `Options` section within ansible's man page, and which defines which should be the ansible execution behavior.
+type AnsibleAdhocOptions struct {
+	// Module name is the module name that will be executed
+	ModuleName string
+	// ModulesArgs are the arguments passed to the module
+	ModulesArgs string
 	// ExtraVars is a map of extra variables used on ansible-playbook execution
 	ExtraVars map[string]interface{}
-	// FlushCache clear the fact cache for every host in inventory
-	FlushCache bool
 	// Inventory specify inventory host path
 	Inventory string
 	// Limit is selected hosts additional pattern
 	Limit string
-	// ListHosts outputs a list of matching hosts
-	ListHosts bool
-	// ListTags list all available tags
-	ListTags bool
-	// ListTasks
-	ListTasks bool
-	// Tags list all tasks that would be executed
-	Tags string
 	// VaultPasswordFile path to the file holding vault decryption key
 	VaultPasswordFile string
 }
 
-// GenerateCommandOptions return a list of options flags to be used on ansible-playbook execution
-func (o *AnsiblePlaybookOptions) GenerateCommandOptions() ([]string, error) {
+// GenerateCommandOptions return a list of options flags to be used on ansible execution
+func (o *AnsibleAdhocOptions) GenerateCommandOptions() ([]string, error) {
 	cmd := []string{}
 
 	if o == nil {
 		return nil, errors.New("(ansible::GenerateCommandOptions)", "AnsiblePlaybookOptions is nil")
 	}
 
-	if o.FlushCache {
-		cmd = append(cmd, FlushCacheFlag)
+	if o.ModuleName != "" {
+		cmd = append(cmd, ModuleNameFlag)
+		cmd = append(cmd, o.ModuleName)
+	}
+
+	if o.ModulesArgs != "" {
+		cmd = append(cmd, ModuleArgsFlag)
+		cmd = append(cmd, o.ModulesArgs)
 	}
 
 	if o.Inventory != "" {
@@ -196,23 +203,6 @@ func (o *AnsiblePlaybookOptions) GenerateCommandOptions() ([]string, error) {
 	if o.Limit != "" {
 		cmd = append(cmd, LimitFlag)
 		cmd = append(cmd, o.Limit)
-	}
-
-	if o.ListHosts {
-		cmd = append(cmd, ListHostsFlag)
-	}
-
-	if o.ListTags {
-		cmd = append(cmd, ListTagsFlag)
-	}
-
-	if o.ListTasks {
-		cmd = append(cmd, ListTasksFlag)
-	}
-
-	if o.Tags != "" {
-		cmd = append(cmd, TagsFlag)
-		cmd = append(cmd, o.Tags)
 	}
 
 	if o.VaultPasswordFile != "" {
@@ -233,7 +223,7 @@ func (o *AnsiblePlaybookOptions) GenerateCommandOptions() ([]string, error) {
 }
 
 // generateExtraVarsCommand return an string which is a json structure having all the extra variable
-func (o *AnsiblePlaybookOptions) generateExtraVarsCommand() (string, error) {
+func (o *AnsibleAdhocOptions) generateExtraVarsCommand() (string, error) {
 
 	extraVars, err := common.ObjectToJSONString(o.ExtraVars)
 	if err != nil {
@@ -242,8 +232,8 @@ func (o *AnsiblePlaybookOptions) generateExtraVarsCommand() (string, error) {
 	return extraVars, nil
 }
 
-// AddExtraVar registers a new extra variable on ansible-playbook options item
-func (o *AnsiblePlaybookOptions) AddExtraVar(name string, value interface{}) error {
+// AddExtraVar registers a new extra variable on ansible options item
+func (o *AnsibleAdhocOptions) AddExtraVar(name string, value interface{}) error {
 
 	if o.ExtraVars == nil {
 		o.ExtraVars = map[string]interface{}{}
@@ -258,13 +248,9 @@ func (o *AnsiblePlaybookOptions) AddExtraVar(name string, value interface{}) err
 	return nil
 }
 
-// String returns AnsiblePlaybookOptions as string
-func (o *AnsiblePlaybookOptions) String() string {
+// String returns AnsibleAdhocOptions as string
+func (o *AnsibleAdhocOptions) String() string {
 	str := ""
-
-	if o.FlushCache {
-		str = fmt.Sprintf("%s %s", str, FlushCacheFlag)
-	}
 
 	if o.Inventory != "" {
 		str = fmt.Sprintf("%s %s %s", str, InventoryFlag, o.Inventory)
@@ -272,22 +258,6 @@ func (o *AnsiblePlaybookOptions) String() string {
 
 	if o.Limit != "" {
 		str = fmt.Sprintf("%s %s %s", str, LimitFlag, o.Limit)
-	}
-
-	if o.ListHosts {
-		str = fmt.Sprintf("%s %s", str, ListHostsFlag)
-	}
-
-	if o.ListTags {
-		str = fmt.Sprintf("%s %s", str, ListTagsFlag)
-	}
-
-	if o.ListTasks {
-		str = fmt.Sprintf("%s %s", str, ListTasksFlag)
-	}
-
-	if o.Tags != "" {
-		str = fmt.Sprintf("%s %s %s", str, TagsFlag, o.Tags)
 	}
 
 	if len(o.ExtraVars) > 0 {

--- a/ansiblePlaybook_test.go
+++ b/ansiblePlaybook_test.go
@@ -16,13 +16,13 @@ import (
 func TestGenerateCommandConnectionOptions(t *testing.T) {
 	tests := []struct {
 		desc                             string
-		ansiblePlaybookConnectionOptions *AnsiblePlaybookConnectionOptions
+		ansiblePlaybookConnectionOptions *AnsibleConnectionOptions
 		err                              error
 		options                          []string
 	}{
 		{
 			desc: "Testing generate connection options",
-			ansiblePlaybookConnectionOptions: &AnsiblePlaybookConnectionOptions{
+			ansiblePlaybookConnectionOptions: &AnsibleConnectionOptions{
 				Connection: "local",
 			},
 			err: nil,
@@ -276,7 +276,7 @@ func TestCommand(t *testing.T) {
 			err:  nil,
 			ansiblePlaybookCmd: &AnsiblePlaybookCmd{
 				Playbook: "test/ansible/site.yml",
-				ConnectionOptions: &AnsiblePlaybookConnectionOptions{
+				ConnectionOptions: &AnsibleConnectionOptions{
 					AskPass:    true,
 					Connection: "local",
 					PrivateKey: "pk",
@@ -292,7 +292,7 @@ func TestCommand(t *testing.T) {
 					},
 					Tags: "tag1",
 				},
-				PrivilegeEscalationOptions: &AnsiblePlaybookPrivilegeEscalationOptions{
+				PrivilegeEscalationOptions: &AnsiblePrivilegeEscalationOptions{
 					Become:        true,
 					BecomeMethod:  "sudo",
 					BecomeUser:    "apenella",
@@ -331,7 +331,7 @@ func TestAnsiblePlaybookCmdString(t *testing.T) {
 			err:  nil,
 			ansiblePlaybookCmd: &AnsiblePlaybookCmd{
 				Playbook: "test/ansible/site.yml",
-				ConnectionOptions: &AnsiblePlaybookConnectionOptions{
+				ConnectionOptions: &AnsibleConnectionOptions{
 					AskPass:    true,
 					Connection: "local",
 					PrivateKey: "pk",
@@ -347,7 +347,7 @@ func TestAnsiblePlaybookCmdString(t *testing.T) {
 					},
 					Tags: "tag1",
 				},
-				PrivilegeEscalationOptions: &AnsiblePlaybookPrivilegeEscalationOptions{
+				PrivilegeEscalationOptions: &AnsiblePrivilegeEscalationOptions{
 					Become:        true,
 					BecomeMethod:  "sudo",
 					BecomeUser:    "apenella",
@@ -407,7 +407,7 @@ func TestRun(t *testing.T) {
 					Write: &w,
 				},
 				Playbook: "test/ansible/site.yml",
-				ConnectionOptions: &AnsiblePlaybookConnectionOptions{
+				ConnectionOptions: &AnsibleConnectionOptions{
 					Connection: "local",
 				},
 				Options: &AnsiblePlaybookOptions{
@@ -422,7 +422,7 @@ func TestRun(t *testing.T) {
 			ansiblePlaybookCmd: &AnsiblePlaybookCmd{
 				Exec:     nil,
 				Playbook: "test/test_site.yml",
-				ConnectionOptions: &AnsiblePlaybookConnectionOptions{
+				ConnectionOptions: &AnsibleConnectionOptions{
 					Connection: "local",
 				},
 				Options: &AnsiblePlaybookOptions{
@@ -437,7 +437,7 @@ func TestRun(t *testing.T) {
 			ansiblePlaybookCmd: &AnsiblePlaybookCmd{
 				StdoutCallback: stdoutcallback.JSONStdoutCallback,
 				Playbook:       "test/test_site.yml",
-				ConnectionOptions: &AnsiblePlaybookConnectionOptions{
+				ConnectionOptions: &AnsibleConnectionOptions{
 					Connection: "local",
 				},
 				Options: &AnsiblePlaybookOptions{
@@ -454,7 +454,7 @@ func TestRun(t *testing.T) {
 					Write: &w,
 				},
 				Playbook: "test/test_site.yml",
-				ConnectionOptions: &AnsiblePlaybookConnectionOptions{
+				ConnectionOptions: &AnsibleConnectionOptions{
 					Connection: "local",
 				},
 				Options: &AnsiblePlaybookOptions{

--- a/examples/become-ansibleplaybook/become-ansibleplaybook.go
+++ b/examples/become-ansibleplaybook/become-ansibleplaybook.go
@@ -6,7 +6,7 @@ import (
 
 func main() {
 
-	ansiblePlaybookConnectionOptions := &ansibler.AnsiblePlaybookConnectionOptions{
+	ansiblePlaybookConnectionOptions := &ansibler.AnsibleConnectionOptions{
 		User: "apenella",
 	}
 
@@ -14,7 +14,7 @@ func main() {
 		Inventory: "127.0.0.1,",
 	}
 
-	ansiblePlaybookPrivilegeEscalationOptions := &ansibler.AnsiblePlaybookPrivilegeEscalationOptions{
+	ansiblePlaybookPrivilegeEscalationOptions := &ansibler.AnsiblePrivilegeEscalationOptions{
 		Become:        true,
 		AskBecomePass: true,
 	}

--- a/examples/cobra-cmd-ansibleplaybook/cobra-cmd-ansibleplaybook.go
+++ b/examples/cobra-cmd-ansibleplaybook/cobra-cmd-ansibleplaybook.go
@@ -56,7 +56,7 @@ func commandHandler(cmd *cobra.Command, args []string) error {
 		return errors.New("(commandHandler)", "Error parsing extra variables", err)
 	}
 
-	ansiblePlaybookConnectionOptions := &ansibler.AnsiblePlaybookConnectionOptions{}
+	ansiblePlaybookConnectionOptions := &ansibler.AnsibleConnectionOptions{}
 	if connectionLocal {
 		ansiblePlaybookConnectionOptions.Connection = "local"
 	}

--- a/examples/myexecutor-ansibleplaybook/myexecutor-ansibleplaybook.go
+++ b/examples/myexecutor-ansibleplaybook/myexecutor-ansibleplaybook.go
@@ -16,7 +16,7 @@ func (e *MyExecutor) Execute(command string, args []string, prefix string) error
 
 func main() {
 
-	ansiblePlaybookConnectionOptions := &ansibler.AnsiblePlaybookConnectionOptions{
+	ansiblePlaybookConnectionOptions := &ansibler.AnsibleConnectionOptions{
 		Connection: "local",
 	}
 

--- a/examples/simple-ansibleadhoc/simple-ansibleadhoc.go
+++ b/examples/simple-ansibleadhoc/simple-ansibleadhoc.go
@@ -1,0 +1,26 @@
+package main
+
+import ansibler "github.com/apenella/go-ansible"
+
+func main() {
+
+	ansibleConnectionOptions := &ansibler.AnsibleConnectionOptions{
+		Connection: "local",
+	}
+
+	ansibleAdhocOptions := &ansibler.AnsibleAdhocOptions{
+		Inventory:  "127.0.0.1,",
+		ModuleName: "ping",
+	}
+
+	adhoc := &ansibler.AnsibleAdhocCmd{
+		Pattern:           "all",
+		Options:           ansibleAdhocOptions,
+		ConnectionOptions: ansibleConnectionOptions,
+	}
+
+	err := adhoc.Run()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/examples/simple-ansibleplaybook-json/simple-ansibleplaybook-json.go
+++ b/examples/simple-ansibleplaybook-json/simple-ansibleplaybook-json.go
@@ -15,7 +15,7 @@ func main() {
 	res := &results.AnsiblePlaybookJSONResults{}
 	buff := new(bytes.Buffer)
 
-	ansiblePlaybookConnectionOptions := &ansibler.AnsiblePlaybookConnectionOptions{
+	ansiblePlaybookConnectionOptions := &ansibler.AnsibleConnectionOptions{
 		Connection: "local",
 		User:       "apenella",
 	}

--- a/examples/simple-ansibleplaybook/simple-ansibleplaybook.go
+++ b/examples/simple-ansibleplaybook/simple-ansibleplaybook.go
@@ -6,7 +6,7 @@ import (
 
 func main() {
 
-	ansiblePlaybookConnectionOptions := &ansibler.AnsiblePlaybookConnectionOptions{
+	ansiblePlaybookConnectionOptions := &ansibler.AnsibleConnectionOptions{
 		Connection: "local",
 		User:       "aleix",
 	}


### PR DESCRIPTION
Started working on the adhoc feature

ConnectionOptions and PrivilegeEscalationOptions are the same for `ansible` and `ansible-playbook` command, that why I moved then to a new the ansible.go file, which could hold shareable struct and method.

Renamed  struct `AnsiblePlaybookConnectionOptions` to `AnsibleConnectionOptions`
Renamed struct `AnsiblePlaybookPrivilegeEscalationOptions` to `AnsiblePrivilegeEscalationOptions`
Added struct `AnsibleAdhocCmd` and `AnsibleAdhocOptions`

I first would like some feedback on the implementation as it's going to break the Public API. I think it could be useful to make this changes as it will ease the process of adding more Ansible feature in the long run. Maybe we could also find a way that wouldn't break the API, I am open to your ideas :)

The PR is functional but there is isn't any Unit Test, I will add them soon ;)
