### PR TITLE
basic stdin support

### DIFF
--- a/examples/user-input/input.yml
+++ b/examples/user-input/input.yml
@@ -1,0 +1,21 @@
+---
+- name: Test playbook for user input
+  hosts: localhost
+  tasks:
+    - name: simple prompt 1
+      pause:
+        prompt: |
+          Type in anything to be echo'ed
+      register: result
+    - name: echo user input
+      debug:
+        msg: you typed {{ result.user_input }}
+    - name: simple prompt 2
+      pause:
+        prompt: |
+          Type in anything to be echo'ed again with more information
+      register: result_2
+    - name: echo user input with more details
+      debug:
+         var: result_2
+        

--- a/examples/user-input/simple-ansibleplaybook-with-prompt.go
+++ b/examples/user-input/simple-ansibleplaybook-with-prompt.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+
+	"github.com/rfc2119/go-ansible/pkg/options"
+	"github.com/rfc2119/go-ansible/pkg/playbook"
+)
+
+func main() {
+
+	ansiblePlaybookConnectionOptions := &options.AnsibleConnectionOptions{
+		Connection: "local",
+		// User:       "aleix",
+	}
+
+	ansiblePlaybookOptions := &playbook.AnsiblePlaybookOptions{
+		Inventory: "127.0.0.1,",
+	}
+
+	playbook := &playbook.AnsiblePlaybookCmd{
+		Playbooks:         []string{"input.yml"},
+		ConnectionOptions: ansiblePlaybookConnectionOptions,
+		Options:           ansiblePlaybookOptions,
+	}
+
+	err := playbook.Run(context.TODO())
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/playbook/ansiblePlaybook.go
+++ b/pkg/playbook/ansiblePlaybook.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/apenella/go-ansible/pkg/execute"
-	"github.com/apenella/go-ansible/pkg/options"
+	"github.com/rfc2119/go-ansible/pkg/execute"
+	"github.com/rfc2119/go-ansible/pkg/options"
 	"github.com/apenella/go-ansible/pkg/stdoutcallback"
 	common "github.com/apenella/go-common-utils/data"
 	errors "github.com/apenella/go-common-utils/error"


### PR DESCRIPTION
In response to #43 , I think it is trivial to add support for stdin. The line

https://github.com/apenella/go-ansible/compare/master...rfc2119:stdin-support?expand=1#diff-766e82546844d23e2726908e27cae47308c4da06a7ae485b47fad8c3e58fb26aR145

connects ansible's `stdin` to the main process' `stdin`. Inside `exec.Command`, Go provides goroutines which handles the interaction between `exec.Cmd`'s standard streams (`Cmd.{Stdin, Stdout, Stderr}`) and the corresponding streams for the external command