### PR TITLE
fix command env when using custom env vars in the default executor

### DIFF
--- a/pkg/adhoc/adhoc_test.go
+++ b/pkg/adhoc/adhoc_test.go
@@ -444,7 +444,7 @@ func TestAnsibleAdhocString(t *testing.T) {
 
 	cmd := options.String()
 
-	expected := " --args args --ask-vault-password --background 11 --check --diff --extra-vars '{\"var1\":\"value1\",\"var2\":false}' --extra-vars @test/ansible/extra_vars.yml --forks 10 --inventory 127.0.0.1, --limit myhost --list-hosts --module-name module-name --module-path /dev/null --one-line --playbook-dir playbook-dir --poll 12 --syntax-check --tree tree --vault-id asdf --vault-password-file /dev/null -vvvv --version"
+	expected := " --args 'args' --ask-vault-password --background 11 --check --diff --extra-vars '{\"var1\":\"value1\",\"var2\":false}' --extra-vars @test/ansible/extra_vars.yml --forks 10 --inventory 127.0.0.1, --limit myhost --list-hosts --module-name module-name --module-path /dev/null --one-line --playbook-dir playbook-dir --poll 12 --syntax-check --tree tree --vault-id asdf --vault-password-file /dev/null -vvvv --version"
 
 	assert.Equal(t, expected, cmd)
 }

--- a/pkg/execute/defaultExecute_test.go
+++ b/pkg/execute/defaultExecute_test.go
@@ -88,3 +88,30 @@ func TestDefaultExecute(t *testing.T) {
 	}
 
 }
+
+func TestEnvVars(t *testing.T) {
+	tests := []struct {
+		desc           string
+		envvars        EnvVars
+		expectedResult []string
+	}{
+		{
+			desc: "basic test case",
+			envvars: EnvVars{
+				"KEY": "VALUE",
+			},
+			expectedResult: []string{"KEY=VALUE"},
+		},
+		{
+			desc:           "empty env",
+			envvars:        EnvVars{},
+			expectedResult: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(tt *testing.T) {
+			assert.Equal(tt, test.expectedResult, test.envvars.Environ())
+		})
+	}
+}


### PR DESCRIPTION
Hi! 

I found that the change done in #81 has introduced a bug when using custom env vars.

In the golang `os/exec` std lib If you instanciate a `Cmd` without specifying environment variables it uses  the default environment variables based on the process attributes provided as command env (see: https://cs.opensource.google/go/go/+/refs/tags/go1.17.7:src/os/exec/exec.go;drc=refs%2Ftags%2Fgo1.17.7;l=226). If you specify custom env vars, the default environment variables are not used.

So when you use the executor with custom environment variables all others environment variables are lost and not available for the ansible playbook run. IMHO it's a wierd behavior. 

In this PR, when custom env vars are defined in the executor, `cmd.Env` is populated with both os environment variables and custom ones.

