### PR TITLE
Add task failure state "unreachable"

### DIFF
--- a/pkg/stdoutcallback/results/JSONResults.go
+++ b/pkg/stdoutcallback/results/JSONResults.go
@@ -101,6 +101,7 @@ type AnsiblePlaybookJSONResultsPlayTaskHostsItem struct {
 	FailedWhenResult bool                   `json:"failed_when_result"`
 	Skipped          bool                   `json:"skipped"`
 	SkipReason       string                 `json:"skip_reason"`
+	Unreachable      string                 `json:"unreachable"`
 }
 
 type AnsiblePlaybookJSONResultsPlayTaskItem struct {


### PR DESCRIPTION
"unreachable" is a separate failure state from "failed". This attribute will make the json field parsable in the task's json stdout output.