### PR TITLE
Fix "unreachable" attribute type to bool

### DIFF
--- a/pkg/stdoutcallback/results/JSONResults.go
+++ b/pkg/stdoutcallback/results/JSONResults.go
@@ -101,7 +101,7 @@ type AnsiblePlaybookJSONResultsPlayTaskHostsItem struct {
 	FailedWhenResult bool                   `json:"failed_when_result"`
 	Skipped          bool                   `json:"skipped"`
 	SkipReason       string                 `json:"skip_reason"`
-	Unreachable      string                 `json:"unreachable"`
+	Unreachable      bool                   `json:"unreachable"`
 }
 
 type AnsiblePlaybookJSONResultsPlayTaskItem struct {


### PR DESCRIPTION
Incorrectly set attribute type as string.
@apenella  my apologies mate, my earlier change might have introduced a bug in the *AnsiblePlaybookJSONResultsPlayTaskHostsItem* struct.
Unreachable is a **bool** as opposed to a string. A v1.1.6 patch release is in order, no?