### PR TITLE
in AnsibleConnectionOptions add quotes on ssh, sftp and scp args

### DIFF
--- a/pkg/options/ansibleCommonOptions.go
+++ b/pkg/options/ansibleCommonOptions.go
@@ -208,19 +208,19 @@ func (o *AnsibleConnectionOptions) String() string {
 	}
 
 	if o.SCPExtraArgs != "" {
-		str = fmt.Sprintf("%s %s %s", str, SCPExtraArgsFlag, o.SCPExtraArgs)
+		str = fmt.Sprintf("%s %s '%s'", str, SCPExtraArgsFlag, o.SCPExtraArgs)
 	}
 
 	if o.SFTPExtraArgs != "" {
-		str = fmt.Sprintf("%s %s %s", str, SFTPExtraArgsFlag, o.SFTPExtraArgs)
+		str = fmt.Sprintf("%s %s '%s'", str, SFTPExtraArgsFlag, o.SFTPExtraArgs)
 	}
 
 	if o.SSHCommonArgs != "" {
-		str = fmt.Sprintf("%s %s %s", str, SSHCommonArgsFlag, o.SSHCommonArgs)
+		str = fmt.Sprintf("%s %s '%s'", str, SSHCommonArgsFlag, o.SSHCommonArgs)
 	}
 
 	if o.SSHExtraArgs != "" {
-		str = fmt.Sprintf("%s %s %s", str, SSHExtraArgsFlag, o.SSHExtraArgs)
+		str = fmt.Sprintf("%s %s '%s'", str, SSHExtraArgsFlag, o.SSHExtraArgs)
 	}
 
 	if o.Timeout > 0 {

--- a/pkg/options/ansibleCommonOptions_test.go
+++ b/pkg/options/ansibleCommonOptions_test.go
@@ -65,7 +65,7 @@ func TestCommandConnectionOptionsString(t *testing.T) {
 
 	cmd := options.String()
 
-	expected := " --ask-pass --connection local --private-key pk --scp-extra-args scp-extra-args --sftp-extra-args sftp-extra-args --ssh-common-args ssh-common-args --ssh-extra-args ssh-extra-args --timeout 10 --user user"
+	expected := " --ask-pass --connection local --private-key pk --scp-extra-args 'scp-extra-args' --sftp-extra-args 'sftp-extra-args' --ssh-common-args 'ssh-common-args' --ssh-extra-args 'ssh-extra-args' --timeout 10 --user user"
 
 	assert.Equal(t, expected, cmd)
 }


### PR DESCRIPTION
resolve #127 