### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: testing
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/apenella/go-ansible/security/code-scanning/26](https://github.com/apenella/go-ansible/security/code-scanning/26)

To fix the issue, we will add a `permissions` block to the workflow. Since the jobs in the workflow only require read access to the repository contents (e.g., for checking out the code), we will set `contents: read` at the workflow level. This will apply the least privilege required to all jobs in the workflow unless overridden at the job level.

The `permissions` block will be added at the root of the workflow, just below the `name` field, to ensure it applies to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
