### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: write
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/apenella/go-ansible/security/code-scanning/24](https://github.com/apenella/go-ansible/security/code-scanning/24)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily interacts with repository contents (e.g., fetching tags, releasing artifacts) and requires `contents: read` and possibly `contents: write` for creating releases. We will also include `pull-requests: write` if the workflow interacts with pull requests.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
